### PR TITLE
Change CLI parsing to allow the default format

### DIFF
--- a/nissaga/cli.py
+++ b/nissaga/cli.py
@@ -69,7 +69,7 @@ def draw_command(
 ):
     "Draws the tree for the input file"
 
-    formats = [f.value for f in format] or ['pdf']
+    formats = [f.value for f in format or [OutputFormat.pdf]]
     return draw(yamlfile, formats)
 
 @app.command()


### PR DESCRIPTION
Hey!

First off, thanks for the cool project!

While trying to run it, I noticed that the default format arguments are not handled properly in `python 3.12`, causing an exception:
```
theodor@lapttop ~/P/S/genealogy (main)> nissaga draw data.yaml
/home/theodor/.local/lib/python3.12/site-packages/pydantic/_internal/_config.py:334: UserWarning: Valid config keys have changed in V2:
* 'fields' has been removed
  warnings.warn(message, UserWarning)
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/theodor/.local/lib/python3.12/site-packages/nissaga/cli.py:72 in draw_command              │
│                                                                                                  │
│    69 ):                                                                                         │
│    70 │   "Draws the tree for the input file"                                                    │
│    71 │                                                                                          │
│ ❱  72 │   formats = [f.value for f in format] or ['pdf']                                         │
│    73 │   return draw(yamlfile, formats)                                                         │
│    74                                                                                            │
│    75 @app.command()                                                                             │
│                                                                                                  │
│ ╭───────────── locals ──────────────╮                                                            │
│ │   format = None                   │                                                            │
│ │ yamlfile = PosixPath('data.yaml') │                                                            │
│ ╰───────────────────────────────────╯                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: 'NoneType' object is not iterable
```

I changed the code slightly to make it work when no format is provided.